### PR TITLE
Add Home Assistant custom integration for Ryse SmartShade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,122 @@
-## MQTT integration for Ryse smart shades.
+## Ryse SmartShade Integration
 
-This allows to integrate Ryse SmartShade bypassing HomeKit bridge directly with MQTT.
-No need for the app or registration either.
-
+Direct BLE integration for Ryse SmartShade motorized blinds/shades. No app, no bridge, no HomeKit, no registration required.
 
 ## Features
-* No-app, no-bridge, "free without registration" onboarding and integration.
-* Home Assistant auto-discovery as a cover entity grouped by device.
-* Fast mode for lightning fast responsiveness (might be detrimental for battery life, since it will keep connection alive)
+
+* No-app, no-bridge, "free without registration" onboarding and integration
+* Home Assistant custom integration with UI-based config flow
+* Automatic Bluetooth discovery of Ryse shades (RZSS devices)
+* Uses Home Assistant's built-in Bluetooth stack (or direct BLE as fallback)
+* Cover entity with full position control (open/close/set position/stop)
+* Fast mode for instant responsiveness (keeps BLE connection alive)
+* Options flow to change fast mode after setup
+* Standalone MQTT mode also available (legacy)
+
+---
+
+## Option 1: Home Assistant Custom Integration (Recommended)
+
+### Install
+
+Copy the `custom_components/ryse_smartshade` folder to your Home Assistant `config/custom_components/` directory:
 
 ```
-git clone https://github.com/ibielopolskyi/ryse_mqtt
-cd ryse_mqtt
+# From this repo
+cp -r custom_components/ryse_smartshade /path/to/ha/config/custom_components/
 ```
 
-## Pairing
+Or with HACS: add this repository as a custom repository (Integration category).
 
-For now pairing is manual as there is no grouping feature.
-Use `bluetoothctl`  as follows:
+Restart Home Assistant.
 
+### Setup
+
+**Automatic Discovery (HA Bluetooth):**
+
+If your HA instance has a Bluetooth adapter, Ryse shades (named `RZSS*`) will be discovered automatically. You'll see a notification to configure them.
+
+**Manual Setup:**
+
+1. Go to **Settings > Devices & Services > Add Integration**
+2. Search for **Ryse SmartShade**
+3. Either select a discovered device or enter the MAC address manually
+
+### Configuration Options
+
+| Option | Description |
+|--------|-------------|
+| **Device name** | Friendly name for the shade |
+| **Use HA Bluetooth** | Use Home Assistant's built-in Bluetooth (recommended) |
+| **Fast mode** | Keep BLE connection alive for instant responsiveness (uses more battery) |
+
+Fast mode can be changed after setup via the integration's **Configure** button.
+
+### Pairing
+
+Put your Ryse shade into pairing mode (3 clicks on the pair button). If using HA Bluetooth, the device should be discovered automatically.
+
+For manual pairing (or if HA Bluetooth is not available):
 ```
 sudo bluetoothctl
-```
-
-Now, we need to locate the Ryse mac address (their name by default is always RZSS):
-```
 menu scan
 pattern RZSS
 back
 scan on
 ```
 
-After locating the mac address, put your Ryse device into pairing mode (3 clicks on pair button) and run:
+After locating the MAC address:
 ```
 trust <YOUR MAC ADDRESS HERE>
 connect <YOUR MAC ADDRESS HERE>
 ```
-Please, note that no pairing is necessary at this point.
 Bluetoothctl will offer to pair and remember. Click yes.
 
-## Configuration
+---
+
+## Option 2: Standalone MQTT Mode (Legacy)
+
+This mode runs as a standalone Python service that bridges BLE to MQTT with Home Assistant auto-discovery.
+
+```
+git clone https://github.com/ibielopolskyi/ryse_mqtt
+cd ryse_mqtt
+```
+
+### Configuration
 ```
 cp example.conf config.conf
 ```
 
-In `config.conf` the `[mqtt]` section is conveniently going to be passed through to the [MQTT Client](https://sbtinstruments.github.io/asyncio-mqtt/connecting-to-the-broker.html)
-In the most cases, merely set up `hostname` variable there
+In `config.conf` the `[mqtt]` section is passed through to the [MQTT Client](https://sbtinstruments.github.io/asyncio-mqtt/connecting-to-the-broker.html).
+In most cases, merely set up `hostname`:
 
 ```
 [mqtt]
 hostname=MQTT host IP
 ```
 
-In the `[ryse]` section create a map of your device preferred names to it's MAC address:
+In the `[ryse]` section create a map of your device preferred names to its MAC address:
 ```
 [ryse]
 A Blind=<Mac Address>
 Another Blind=<Mac Address>
 ```
 
-In `home_assistant` section set `discovery_topic` and `device_name` . Discovery topic by default is `homeassistant` and `device_name` will be used in Home Assistant device identifier to group entities. 
+In `home_assistant` section set `discovery_topic` and `device_name`. Discovery topic by default is `homeassistant` and `device_name` will be used in Home Assistant device identifier to group entities.
 ```
 [home_assistant]
 discovery_topic=homeassistant
 device_name=Ryse Controller
 ```
 
-Finally, if you don't want to wait for reconnect, define specific blinds in `[fast]` section. Especially useful when your shades are part of automation. 
+For instant responsiveness, define specific blinds in `[fast]` section:
 ```
 [fast]
 A blind=true
 ```
 
-## Run!
+### Run
 
 ```
 python -m venv .venv
@@ -85,9 +129,13 @@ Or:
 python ryse_mqtt <path to config file>
 ```
 
+---
+
 ## FAQ
 
-* Ryse blind not connecting after restart.
+* **Ryse blind not connecting after restart.**
+  Go to `bluetoothctl` and run `disconnect <RYSE MAC ADDRESS>` or simply wait. It will expire the previous session and reconnect.
 
-A: go to `bluetoothctl` and run `disconnect <RYSE MAC ADDRESS>` or simply wait. It will expire previous session and reconnect.
+* **HA Bluetooth vs Direct BLE?**
+  HA Bluetooth is recommended as it shares the adapter with other integrations and supports automatic discovery. Direct BLE is useful if the shade is paired to a different adapter or remote host.
 

--- a/custom_components/ryse_smartshade/__init__.py
+++ b/custom_components/ryse_smartshade/__init__.py
@@ -1,0 +1,115 @@
+"""The Ryse SmartShade integration.
+
+Controls Ryse SmartShade BLE motorized blinds/shades directly via Bluetooth,
+without requiring the Ryse app, bridge, or HomeKit.
+
+Supports two BLE transport modes:
+  - Home Assistant Bluetooth (default): Uses HA's built-in Bluetooth adapter
+    management for automatic discovery and connection handling.
+  - Direct BLE: Connects to the shade via bleak directly, useful when the
+    shade is paired to a different Bluetooth adapter or remote host.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.bluetooth import (
+    BluetoothCallbackMatcher,
+    BluetoothChange,
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+    async_ble_device_from_address,
+    async_register_callback,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, Platform
+from homeassistant.core import HomeAssistant, callback
+
+from .ble_device import RyseSmartShadeDevice
+from .const import CONF_FAST_MODE, CONF_USE_HA_BLE, DEFAULT_FAST_MODE, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.COVER]
+
+type RyseSmartShadeConfigEntry = ConfigEntry[RyseSmartShadeDevice]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: RyseSmartShadeConfigEntry
+) -> bool:
+    """Set up Ryse SmartShade from a config entry."""
+    address: str = entry.data[CONF_ADDRESS]
+    name: str = entry.data.get(CONF_NAME, f"Ryse Shade {address[-5:]}")
+    use_ha_ble: bool = entry.data.get(CONF_USE_HA_BLE, True)
+    fast_mode: bool = entry.options.get(CONF_FAST_MODE, DEFAULT_FAST_MODE)
+
+    ble_device = None
+    if use_ha_ble:
+        ble_device = async_ble_device_from_address(hass, address, connectable=True)
+        if ble_device:
+            _LOGGER.debug("Using HA Bluetooth device for %s", address)
+        else:
+            _LOGGER.warning(
+                "HA Bluetooth device not found for %s; will use direct BLE",
+                address,
+            )
+
+    device = RyseSmartShadeDevice(
+        address=address,
+        name=name,
+        fast_mode=fast_mode,
+        ble_device=ble_device,
+    )
+
+    entry.runtime_data = device
+
+    # Register a callback to update the BLEDevice when HA sees new advertisements
+    if use_ha_ble:
+
+        @callback
+        def _async_update_ble_device(
+            service_info: BluetoothServiceInfoBleak, change: BluetoothChange
+        ) -> None:
+            """Update the BLEDevice when a new advertisement is received."""
+            _LOGGER.debug("New BLE advertisement from %s", service_info.address)
+            device.set_ble_device(service_info.device)
+
+        entry.async_on_unload(
+            async_register_callback(
+                hass,
+                _async_update_ble_device,
+                BluetoothCallbackMatcher(address=address),
+                BluetoothScanningMode.ACTIVE,
+            )
+        )
+
+    # Start the connection loop (connects immediately if fast_mode)
+    await device.start_connection_loop()
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Handle options updates
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: RyseSmartShadeConfigEntry
+) -> bool:
+    """Unload a Ryse SmartShade config entry."""
+    device: RyseSmartShadeDevice = entry.runtime_data
+
+    await device.stop_connection_loop()
+    await device.disconnect()
+
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: RyseSmartShadeConfigEntry
+) -> None:
+    """Handle options updates."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/ryse_smartshade/ble_device.py
+++ b/custom_components/ryse_smartshade/ble_device.py
@@ -1,0 +1,269 @@
+"""BLE GATT communication for Ryse SmartShade devices.
+
+Supports two modes:
+  1. HA Bluetooth: Uses Home Assistant's built-in Bluetooth stack for device
+     discovery and connection management.
+  2. Direct BLE: Uses bleak directly (for systems where HA Bluetooth is
+     unavailable or the adapter is on a remote host).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable
+
+from bleak import BleakClient
+from bleak.backends.device import BLEDevice
+from bleak_retry_connector import establish_connection
+
+from .const import (
+    BLE_CONNECT_TIMEOUT,
+    CMD_HEADER,
+    CMD_PARAM1,
+    CMD_PARAM2,
+    CMD_TYPE,
+    MOTION_CLOSING,
+    MOTION_OPENING,
+    MOTION_STOPPED,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    RECONNECT_INTERVAL,
+    STATE_MOTION_INDEX,
+    STATE_POSITION_INDEX,
+    UUID_RX,
+    UUID_TX,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RyseSmartShadeDevice:
+    """Manages BLE communication with a single Ryse SmartShade."""
+
+    def __init__(
+        self,
+        address: str,
+        name: str,
+        fast_mode: bool = False,
+        ble_device: BLEDevice | None = None,
+    ) -> None:
+        """Initialize the device.
+
+        Args:
+            address: The BLE MAC address.
+            name: Friendly name for the shade.
+            fast_mode: If True, keep the BLE connection alive.
+            ble_device: Optional BLEDevice from HA Bluetooth discovery.
+        """
+        self.address = address
+        self.name = name
+        self.fast_mode = fast_mode
+        self._ble_device: BLEDevice | None = ble_device
+        self._client: BleakClient | None = None
+        self._lock = asyncio.Lock()
+
+        # State
+        self.position: int = 0
+        self.state: str = "STOPPED"
+        self.moving: bool = False
+        self.available: bool = False
+
+        # Callbacks
+        self._state_callbacks: list[Callable[[], None]] = []
+        self._running: bool = False
+        self._connection_task: asyncio.Task | None = None
+
+    def set_ble_device(self, ble_device: BLEDevice) -> None:
+        """Update the BLEDevice reference (from HA Bluetooth scanner)."""
+        self._ble_device = ble_device
+
+    def register_callback(self, callback: Callable[[], None]) -> Callable[[], None]:
+        """Register a callback for state updates. Returns unregister function."""
+        self._state_callbacks.append(callback)
+
+        def unregister() -> None:
+            if callback in self._state_callbacks:
+                self._state_callbacks.remove(callback)
+
+        return unregister
+
+    def _fire_callbacks(self) -> None:
+        """Notify all registered callbacks of a state change."""
+        for callback in self._state_callbacks:
+            try:
+                callback()
+            except Exception:
+                _LOGGER.exception("Error in state callback")
+
+    @staticmethod
+    def _build_position_command(position: int) -> bytes:
+        """Build the BLE command bytes for a target position (0-100).
+
+        The device expects the inverted position value.
+        """
+        device_pos = POSITION_OPEN - position
+        return bytes([CMD_HEADER, CMD_TYPE, CMD_PARAM1, CMD_PARAM2, device_pos, device_pos + 2])
+
+    def _parse_state(self, data: bytearray | bytes) -> None:
+        """Parse a BLE notification/read response and update internal state."""
+        if len(data) < 6:
+            _LOGGER.warning("Received short BLE response (%d bytes)", len(data))
+            return
+
+        motion = int(data[STATE_MOTION_INDEX])
+        raw_position = int(data[STATE_POSITION_INDEX])
+
+        if motion == MOTION_STOPPED:
+            self.moving = False
+        elif motion == MOTION_OPENING:
+            self.state = "OPENING"
+            self.moving = True
+        elif motion == MOTION_CLOSING:
+            self.state = "CLOSING"
+            self.moving = True
+
+        if not self.moving:
+            self.state = "STOPPED"
+            if raw_position == 0:
+                self.state = "OPEN"
+            elif raw_position == 100:
+                self.state = "CLOSED"
+
+        self.position = POSITION_OPEN - raw_position
+
+        _LOGGER.debug(
+            "%s state=%s position=%d moving=%s",
+            self.name,
+            self.state,
+            self.position,
+            self.moving,
+        )
+        self._fire_callbacks()
+
+    def _on_notification(self, _sender: Any, data: bytearray) -> None:
+        """Handle BLE GATT notification from the shade."""
+        self._parse_state(data)
+
+    def _on_disconnect(self, _client: BleakClient) -> None:
+        """Handle BLE disconnection."""
+        _LOGGER.info("%s disconnected", self.name)
+        self.available = False
+        self._fire_callbacks()
+
+    @property
+    def is_connected(self) -> bool:
+        """Return True if the BLE client is connected."""
+        return self._client is not None and self._client.is_connected
+
+    async def connect(self) -> bool:
+        """Establish a BLE connection and subscribe to notifications."""
+        async with self._lock:
+            if self.is_connected:
+                return True
+            try:
+                if self._ble_device is not None:
+                    # Use HA Bluetooth stack via bleak_retry_connector
+                    self._client = await establish_connection(
+                        BleakClient,
+                        self._ble_device,
+                        self.name,
+                        disconnected_callback=self._on_disconnect,
+                        max_attempts=3,
+                    )
+                else:
+                    # Direct bleak connection (fallback)
+                    self._client = BleakClient(
+                        self.address,
+                        disconnected_callback=self._on_disconnect,
+                        timeout=BLE_CONNECT_TIMEOUT,
+                    )
+                    await self._client.connect()
+
+                if self._client.is_connected:
+                    self.available = True
+                    # Read initial state
+                    initial_data = await self._client.read_gatt_char(UUID_RX)
+                    self._parse_state(initial_data)
+                    # Subscribe to notifications for live updates
+                    await self._client.start_notify(UUID_RX, self._on_notification)
+                    _LOGGER.info("%s connected", self.name)
+                    self._fire_callbacks()
+                    return True
+
+            except Exception:
+                _LOGGER.exception("Failed to connect to %s", self.name)
+                self.available = False
+                self._fire_callbacks()
+            return False
+
+    async def disconnect(self) -> None:
+        """Disconnect from the BLE device."""
+        async with self._lock:
+            if self._client and self._client.is_connected:
+                try:
+                    await self._client.disconnect()
+                except Exception:
+                    _LOGGER.exception("Error disconnecting %s", self.name)
+            self._client = None
+            self.available = False
+            self._fire_callbacks()
+
+    async def async_set_position(self, position: int) -> None:
+        """Set the shade position (0=closed, 100=open)."""
+        position = max(POSITION_CLOSED, min(POSITION_OPEN, position))
+        if not self.is_connected:
+            await self.connect()
+        if self.is_connected:
+            cmd = self._build_position_command(position)
+            await self._client.write_gatt_char(UUID_TX, cmd)
+            _LOGGER.debug("%s set position to %d", self.name, position)
+        else:
+            _LOGGER.warning("Cannot set position: %s not connected", self.name)
+
+    async def async_open(self) -> None:
+        """Fully open the shade."""
+        await self.async_set_position(POSITION_OPEN)
+
+    async def async_close(self) -> None:
+        """Fully close the shade."""
+        await self.async_set_position(POSITION_CLOSED)
+
+    async def async_stop(self) -> None:
+        """Stop the shade at its current position.
+
+        The Ryse protocol does not have a dedicated stop command.
+        We send the current known position which effectively stops movement.
+        """
+        await self.async_set_position(self.position)
+
+    async def start_connection_loop(self) -> None:
+        """Start the background connection loop (for fast mode)."""
+        if self._running:
+            return
+        self._running = True
+        self._connection_task = asyncio.ensure_future(self._connection_loop())
+
+    async def stop_connection_loop(self) -> None:
+        """Stop the background connection loop."""
+        self._running = False
+        if self._connection_task:
+            self._connection_task.cancel()
+            try:
+                await self._connection_task
+            except asyncio.CancelledError:
+                pass
+            self._connection_task = None
+
+    async def _connection_loop(self) -> None:
+        """Maintain the BLE connection when fast mode is enabled."""
+        while self._running:
+            try:
+                if not self.is_connected and self.fast_mode:
+                    await self.connect()
+                await asyncio.sleep(RECONNECT_INTERVAL)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                _LOGGER.exception("Connection loop error for %s", self.name)
+                await asyncio.sleep(RECONNECT_INTERVAL)

--- a/custom_components/ryse_smartshade/config_flow.py
+++ b/custom_components/ryse_smartshade/config_flow.py
@@ -1,0 +1,245 @@
+"""Config flow for Ryse SmartShade integration.
+
+Supports:
+  - Automatic discovery via HA Bluetooth (devices with local_name RZSS*)
+  - Manual configuration by entering the BLE MAC address
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.bluetooth import (
+    BluetoothServiceInfoBleak,
+    async_discovered_service_info,
+)
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.core import callback
+
+from .const import (
+    CONF_FAST_MODE,
+    CONF_USE_HA_BLE,
+    DEFAULT_FAST_MODE,
+    DEFAULT_USE_HA_BLE,
+    DEVICE_NAME_PREFIX,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RyseSmartShadeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Ryse SmartShade."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovery_info: BluetoothServiceInfoBleak | None = None
+        self._discovered_address: str | None = None
+        self._discovered_name: str | None = None
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> ConfigFlowResult:
+        """Handle Bluetooth discovery."""
+        _LOGGER.debug(
+            "Bluetooth discovery: %s (%s)",
+            discovery_info.name,
+            discovery_info.address,
+        )
+        await self.async_set_unique_id(discovery_info.address.upper())
+        self._abort_if_unique_id_configured()
+
+        self._discovery_info = discovery_info
+        self._discovered_address = discovery_info.address
+        self._discovered_name = discovery_info.name or "Ryse SmartShade"
+
+        self.context["title_placeholders"] = {
+            "name": self._discovered_name,
+            "address": self._discovered_address,
+        }
+        return await self.async_step_bluetooth_confirm()
+
+    async def async_step_bluetooth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm Bluetooth discovery."""
+        if user_input is not None:
+            name = user_input.get(CONF_NAME, self._discovered_name)
+            return self.async_create_entry(
+                title=name,
+                data={
+                    CONF_ADDRESS: self._discovered_address,
+                    CONF_NAME: name,
+                    CONF_USE_HA_BLE: True,
+                },
+                options={
+                    CONF_FAST_MODE: user_input.get(CONF_FAST_MODE, DEFAULT_FAST_MODE),
+                },
+            )
+
+        return self.async_show_form(
+            step_id="bluetooth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=self._discovered_name): str,
+                    vol.Optional(CONF_FAST_MODE, default=DEFAULT_FAST_MODE): bool,
+                }
+            ),
+            description_placeholders={
+                "name": self._discovered_name,
+                "address": self._discovered_address,
+            },
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle user-initiated setup.
+
+        Offers a list of discovered Bluetooth devices or manual entry.
+        """
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS]
+            if address == "manual":
+                return await self.async_step_manual()
+
+            # User selected a discovered device
+            await self.async_set_unique_id(address.upper())
+            self._abort_if_unique_id_configured()
+
+            # Find the discovery info for this address
+            service_infos = async_discovered_service_info(self.hass)
+            ble_name = "Ryse SmartShade"
+            for info in service_infos:
+                if info.address.upper() == address.upper():
+                    ble_name = info.name or ble_name
+                    break
+
+            self._discovered_address = address
+            self._discovered_name = ble_name
+            return await self.async_step_bluetooth_confirm()
+
+        # Build list of discovered Ryse devices
+        discovered: dict[str, str] = {}
+        service_infos = async_discovered_service_info(self.hass)
+        for info in service_infos:
+            if info.name and info.name.startswith(DEVICE_NAME_PREFIX):
+                # Check this device isn't already configured
+                if not self._address_already_configured(info.address):
+                    discovered[info.address.upper()] = (
+                        f"{info.name} ({info.address})"
+                    )
+
+        if not discovered:
+            return await self.async_step_manual()
+
+        # Add manual entry option
+        discovered["manual"] = "Enter address manually..."
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ADDRESS): vol.In(discovered),
+                }
+            ),
+        )
+
+    async def async_step_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle manual MAC address entry."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS].upper().strip()
+
+            # Basic MAC address validation
+            if not self._validate_mac(address):
+                errors[CONF_ADDRESS] = "invalid_mac"
+            else:
+                await self.async_set_unique_id(address)
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=user_input.get(CONF_NAME, f"Ryse Shade {address[-5:]}"),
+                    data={
+                        CONF_ADDRESS: address,
+                        CONF_NAME: user_input.get(
+                            CONF_NAME, f"Ryse Shade {address[-5:]}"
+                        ),
+                        CONF_USE_HA_BLE: user_input.get(
+                            CONF_USE_HA_BLE, DEFAULT_USE_HA_BLE
+                        ),
+                    },
+                    options={
+                        CONF_FAST_MODE: user_input.get(
+                            CONF_FAST_MODE, DEFAULT_FAST_MODE
+                        ),
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="manual",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ADDRESS): str,
+                    vol.Required(CONF_NAME, default="Ryse SmartShade"): str,
+                    vol.Optional(CONF_USE_HA_BLE, default=DEFAULT_USE_HA_BLE): bool,
+                    vol.Optional(CONF_FAST_MODE, default=DEFAULT_FAST_MODE): bool,
+                }
+            ),
+            errors=errors,
+        )
+
+    def _address_already_configured(self, address: str) -> bool:
+        """Check if a device address is already configured."""
+        for entry in self._async_current_entries():
+            if entry.data.get(CONF_ADDRESS, "").upper() == address.upper():
+                return True
+        return False
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Create the options flow."""
+        return RyseSmartShadeOptionsFlow()
+
+    @staticmethod
+    def _validate_mac(address: str) -> bool:
+        """Validate a MAC address format (XX:XX:XX:XX:XX:XX)."""
+        parts = address.split(":")
+        if len(parts) != 6:
+            return False
+        return all(len(p) == 2 and all(c in "0123456789ABCDEF" for c in p) for p in parts)
+
+
+class RyseSmartShadeOptionsFlow(OptionsFlow):
+    """Handle options for Ryse SmartShade."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_FAST_MODE,
+                        default=self.config_entry.options.get(
+                            CONF_FAST_MODE, DEFAULT_FAST_MODE
+                        ),
+                    ): bool,
+                }
+            ),
+        )

--- a/custom_components/ryse_smartshade/const.py
+++ b/custom_components/ryse_smartshade/const.py
@@ -1,0 +1,43 @@
+"""Constants for the Ryse SmartShade integration."""
+
+DOMAIN = "ryse_smartshade"
+
+# BLE GATT UUIDs
+UUID_TX = "a72f2802-b0bd-498b-b4cd-4a3901388238"
+UUID_RX = "a72f2801-b0bd-498b-b4cd-4a3901388238"
+UUID_SERVICE = "a72f2800-b0bd-498b-b4cd-4a3901388238"
+
+# BLE device default name prefix
+DEVICE_NAME_PREFIX = "RZSS"
+
+# Configuration keys
+CONF_USE_HA_BLE = "use_ha_ble"
+CONF_FAST_MODE = "fast_mode"
+
+# Default values
+DEFAULT_FAST_MODE = False
+DEFAULT_USE_HA_BLE = True
+
+# Position constants
+POSITION_OPEN = 100
+POSITION_CLOSED = 0
+
+# BLE command structure
+CMD_HEADER = 245  # 0xF5
+CMD_TYPE = 3
+CMD_PARAM1 = 1
+CMD_PARAM2 = 1
+
+# State byte indices in BLE response
+STATE_MOTION_INDEX = 5
+STATE_POSITION_INDEX = 4
+
+# Motion states from device
+MOTION_STOPPED = 0
+MOTION_OPENING = 1
+MOTION_CLOSING = 2
+
+# Reconnection settings
+RECONNECT_INTERVAL = 5.0
+BLE_DISCONNECT_DELAY = 0.5
+BLE_CONNECT_TIMEOUT = 30.0

--- a/custom_components/ryse_smartshade/cover.py
+++ b/custom_components/ryse_smartshade/cover.py
@@ -1,0 +1,132 @@
+"""Cover platform for Ryse SmartShade."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .ble_device import RyseSmartShadeDevice
+from .const import DOMAIN, POSITION_CLOSED, POSITION_OPEN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Ryse SmartShade cover from a config entry."""
+    device: RyseSmartShadeDevice = entry.runtime_data
+    async_add_entities([RyseSmartShadeCover(device, entry)])
+
+
+class RyseSmartShadeCover(CoverEntity):
+    """Representation of a Ryse SmartShade as a Home Assistant Cover."""
+
+    _attr_device_class = CoverDeviceClass.SHADE
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.STOP
+    )
+    _attr_has_entity_name = True
+    _attr_name = None  # Use device name as entity name
+
+    def __init__(
+        self,
+        device: RyseSmartShadeDevice,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the cover entity."""
+        self._device = device
+        self._entry = entry
+        self._unregister_callback: callable | None = None
+
+        address = entry.data[CONF_ADDRESS]
+        name = entry.data.get(CONF_NAME, device.name)
+
+        self._attr_unique_id = address.upper().replace(":", "_")
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, address.upper())},
+            name=name,
+            manufacturer="Ryse",
+            model="SmartShade",
+            sw_version="1.0.0",
+            connections={("bluetooth", address.upper())},
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to hass."""
+        self._unregister_callback = self._device.register_callback(
+            self._handle_state_update
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity is about to be removed from hass."""
+        if self._unregister_callback:
+            self._unregister_callback()
+            self._unregister_callback = None
+
+    @callback
+    def _handle_state_update(self) -> None:
+        """Handle a state update from the BLE device."""
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Return True if the shade is available."""
+        return self._device.available
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return True if the shade is fully closed."""
+        if not self._device.available:
+            return None
+        return self._device.position == POSITION_CLOSED
+
+    @property
+    def is_opening(self) -> bool:
+        """Return True if the shade is opening."""
+        return self._device.state == "OPENING"
+
+    @property
+    def is_closing(self) -> bool:
+        """Return True if the shade is closing."""
+        return self._device.state == "CLOSING"
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return the current position (0=closed, 100=open)."""
+        if not self._device.available:
+            return None
+        return self._device.position
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the shade."""
+        await self._device.async_open()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the shade."""
+        await self._device.async_close()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Set the shade to a specific position."""
+        position = kwargs.get("position", POSITION_OPEN)
+        await self._device.async_set_position(position)
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the shade movement."""
+        await self._device.async_stop()

--- a/custom_components/ryse_smartshade/manifest.json
+++ b/custom_components/ryse_smartshade/manifest.json
@@ -1,0 +1,23 @@
+{
+  "domain": "ryse_smartshade",
+  "name": "Ryse SmartShade",
+  "bluetooth": [
+    {
+      "connectable": true,
+      "local_name": "RZSS*"
+    },
+    {
+      "connectable": true,
+      "service_uuid": "a72f2800-b0bd-498b-b4cd-4a3901388238"
+    }
+  ],
+  "codeowners": ["@ibielopolskyi"],
+  "config_flow": true,
+  "dependencies": ["bluetooth_adapters"],
+  "documentation": "https://github.com/ibielopolskyi/ryse_mqtt",
+  "integration_type": "device",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/ibielopolskyi/ryse_mqtt/issues",
+  "requirements": ["bleak>=0.21.0", "bleak-retry-connector>=3.4.0"],
+  "version": "1.0.0"
+}

--- a/custom_components/ryse_smartshade/strings.json
+++ b/custom_components/ryse_smartshade/strings.json
@@ -1,0 +1,47 @@
+{
+  "config": {
+    "flow_title": "Ryse SmartShade {name}",
+    "step": {
+      "user": {
+        "title": "Select Ryse SmartShade",
+        "description": "Select a discovered Ryse SmartShade device or choose manual entry.",
+        "data": {
+          "address": "Device"
+        }
+      },
+      "bluetooth_confirm": {
+        "title": "Confirm Ryse SmartShade",
+        "description": "Found Ryse SmartShade **{name}** ({address}). Configure and add this device.",
+        "data": {
+          "name": "Device name",
+          "fast_mode": "Fast mode (keep BLE connection alive)"
+        }
+      },
+      "manual": {
+        "title": "Manual Configuration",
+        "description": "Enter the Bluetooth MAC address of your Ryse SmartShade. The device must be paired via bluetoothctl first.",
+        "data": {
+          "address": "Bluetooth MAC address (XX:XX:XX:XX:XX:XX)",
+          "name": "Device name",
+          "use_ha_ble": "Use Home Assistant Bluetooth",
+          "fast_mode": "Fast mode (keep BLE connection alive)"
+        }
+      }
+    },
+    "error": {
+      "invalid_mac": "Invalid MAC address format. Use XX:XX:XX:XX:XX:XX."
+    },
+    "abort": {
+      "already_configured": "This device is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "fast_mode": "Fast mode (keep BLE connection alive for instant responsiveness)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/ryse_smartshade/translations/en.json
+++ b/custom_components/ryse_smartshade/translations/en.json
@@ -1,0 +1,47 @@
+{
+  "config": {
+    "flow_title": "Ryse SmartShade {name}",
+    "step": {
+      "user": {
+        "title": "Select Ryse SmartShade",
+        "description": "Select a discovered Ryse SmartShade device or choose manual entry.",
+        "data": {
+          "address": "Device"
+        }
+      },
+      "bluetooth_confirm": {
+        "title": "Confirm Ryse SmartShade",
+        "description": "Found Ryse SmartShade **{name}** ({address}). Configure and add this device.",
+        "data": {
+          "name": "Device name",
+          "fast_mode": "Fast mode (keep BLE connection alive)"
+        }
+      },
+      "manual": {
+        "title": "Manual Configuration",
+        "description": "Enter the Bluetooth MAC address of your Ryse SmartShade. The device must be paired via bluetoothctl first.",
+        "data": {
+          "address": "Bluetooth MAC address (XX:XX:XX:XX:XX:XX)",
+          "name": "Device name",
+          "use_ha_ble": "Use Home Assistant Bluetooth",
+          "fast_mode": "Fast mode (keep BLE connection alive)"
+        }
+      }
+    },
+    "error": {
+      "invalid_mac": "Invalid MAC address format. Use XX:XX:XX:XX:XX:XX."
+    },
+    "abort": {
+      "already_configured": "This device is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "fast_mode": "Fast mode (keep BLE connection alive for instant responsiveness)"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Package Ryse SmartShade BLE control as a proper HA custom integration
(custom_components/ryse_smartshade) with:

- Config flow with automatic Bluetooth discovery (RZSS* local_name match)
  and manual MAC address entry
- HA Bluetooth integration support via bleak_retry_connector with
  BluetoothCallbackMatcher for live BLEDevice updates
- Direct BLE fallback for systems without HA Bluetooth
- Cover entity with full position control (open/close/set_position/stop)
- Fast mode option (keep BLE connection alive) configurable via OptionsFlow
- All existing BLE GATT protocol logic preserved (command format, state
  parsing, position inversion, notification subscriptions)

The original standalone MQTT mode remains fully functional alongside.

https://claude.ai/code/session_01GQ1T34trfNG17f7Qt7ky9j